### PR TITLE
Update composer.json fabpot/goutte constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php":                           ">=5.3.1",
         "behat/mink":                    "~1.6@dev",
         "behat/mink-browserkit-driver":  "~1.2@dev",
-        "fabpot/goutte":                 "~1.0.4|~2.0|~3.1"
+        "fabpot/goutte":                 "~1.0.4|~2.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
Removing goutte version 3 from supported driver versions. The problem being that behat/mink-extension passes server_parameters into the guzzle constructor nested in the 'default' key in the GoutteFactory::buildGuzzle4Client method. Guzzle 6 no longer uses the 'defaults' key. Thus the guzzle 6 client does not get the correct configuration.

see:
https://github.com/Behat/MinkExtension/blob/master/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php#L71-L75
https://github.com/Behat/MinkExtension/blob/master/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php#L87-L95
https://github.com/Behat/MinkExtension/blob/master/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php#L97-L103

This can be restored once a pull request has been completed to the behat/mink-extension repo to add support for goutte3 http client creation. For now it would be ideal to reduce the composer constraint so as to not force people to require "fabpot/goutte": "~2.0" in order to use the driver with guzzle options since in most dev environments people are going to be passing 'verify' => false for self-signed certs.